### PR TITLE
Do not escape content of Code Blocks

### DIFF
--- a/src/Renderer/Inline/CodeRenderer.php
+++ b/src/Renderer/Inline/CodeRenderer.php
@@ -8,7 +8,6 @@ use League\CommonMark\Extension\CommonMark\Node\Inline\Code;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
-use League\CommonMark\Util\Xml;
 
 class CodeRenderer implements NodeRendererInterface
 {
@@ -23,7 +22,7 @@ class CodeRenderer implements NodeRendererInterface
     {
         Code::assertInstanceOf($node);
 
-        $content = Xml::escape($node->getLiteral());
+        $content = $node->getLiteral();
 
         return "`$content`";
     }

--- a/tests/stubs/kitchen-sink.md
+++ b/tests/stubs/kitchen-sink.md
@@ -168,3 +168,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README now contains answers to common questions about CHANGELOGs
 - Good examples and basic guidelines, including proper date formatting.
 - Counter-examples: "What makes unicorns cry?"
+- `\Class->getFoo()`


### PR DESCRIPTION
This PR stops the `CodeRenderer` from escaping the content.

## Related Issues
- https://github.com/stefanzweifel/changelog-updater-action/issues/3#issuecomment-979174161