### PR TITLE
Drop PHP 8.0 support, update dependencies and code standards

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1, 8.2]
+        php: [8.1, 8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
@@ -34,4 +34,4 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit --no-coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .php_cs
 .php_cs.cache
+.phpunit.cache
 .phpunit.result.cache
 build
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpunit/phpunit": "^9.5",
+        "rector/rector": "^0.15.17",
         "spatie/ray": "^1.28",
         "vimeo/psalm": "^4.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "league/commonmark": "^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.0",
         "rector/rector": "^0.15.17",
         "spatie/ray": "^1.28",
         "vimeo/psalm": "^5.7"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpunit/phpunit": "^9.5",
         "rector/rector": "^0.15.17",
         "spatie/ray": "^1.28",
-        "vimeo/psalm": "^4.8"
+        "vimeo/psalm": "^5.7"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    executionOrder="random"
-    failOnWarning="true"
-    failOnRisky="true"
-    failOnEmptyTestSuite="true"
-    beStrictAboutOutputDuringTests="true"
-    verbose="true"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         backupGlobals="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         executionOrder="random"
+         failOnWarning="true"
+         failOnRisky="true"
+         failOnEmptyTestSuite="true"
+         beStrictAboutOutputDuringTests="true"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,8 +1,10 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="4"
+    errorLevel="3"
     findUnusedVariablesAndParams="true"
     resolveFromConfigFile="true"
+    findUnusedCode="true"
+    findUnusedBaselineEntry="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/rector.php
+++ b/rector.php
@@ -16,7 +16,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         SetList::TYPE_DECLARATION,
         SetList::PRIVATIZATION,
-        LevelSetList::UP_TO_PHP_80,
-        PHPUnitSetList::PHPUNIT_91,
+        LevelSetList::UP_TO_PHP_81,
+        PHPUnitSetList::PHPUNIT_100,
     ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $rectorConfig->sets([
+        SetList::TYPE_DECLARATION,
+        SetList::PRIVATIZATION,
+        LevelSetList::UP_TO_PHP_80,
+        PHPUnitSetList::PHPUNIT_91,
+    ]);
+};

--- a/src/MarkdownRendererExtension.php
+++ b/src/MarkdownRendererExtension.php
@@ -64,6 +64,9 @@ use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\StrongRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\TaskListItemMarkerRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\TextRenderer;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class MarkdownRendererExtension implements ExtensionInterface, ConfigurableExtensionInterface
 {
     public function configureSchema(ConfigurationBuilderInterface $builder): void

--- a/src/Renderer/Block/BlockQuoteRenderer.php
+++ b/src/Renderer/Block/BlockQuoteRenderer.php
@@ -9,7 +9,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class BlockQuoteRenderer implements NodeRendererInterface
+final class BlockQuoteRenderer implements NodeRendererInterface
 {
     public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
     {

--- a/src/Renderer/Block/DocumentRenderer.php
+++ b/src/Renderer/Block/DocumentRenderer.php
@@ -9,7 +9,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class DocumentRenderer implements NodeRendererInterface
+final class DocumentRenderer implements NodeRendererInterface
 {
     /**
      * @param Document $node

--- a/src/Renderer/Block/FencedCodeRenderer.php
+++ b/src/Renderer/Block/FencedCodeRenderer.php
@@ -9,7 +9,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class FencedCodeRenderer implements NodeRendererInterface
+final class FencedCodeRenderer implements NodeRendererInterface
 {
     /**
      * @param FencedCode $node

--- a/src/Renderer/Block/HeadingRenderer.php
+++ b/src/Renderer/Block/HeadingRenderer.php
@@ -9,7 +9,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class HeadingRenderer implements NodeRendererInterface
+final class HeadingRenderer implements NodeRendererInterface
 {
     /**
      * @param Heading $node
@@ -18,7 +18,7 @@ class HeadingRenderer implements NodeRendererInterface
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
     {
         Heading::assertInstanceOf($node);
 

--- a/src/Renderer/Block/HtmlBlockRenderer.php
+++ b/src/Renderer/Block/HtmlBlockRenderer.php
@@ -12,7 +12,7 @@ use League\CommonMark\Util\HtmlFilter;
 use League\Config\ConfigurationAwareInterface;
 use League\Config\ConfigurationInterface;
 
-class HtmlBlockRenderer implements NodeRendererInterface, ConfigurationAwareInterface
+final class HtmlBlockRenderer implements NodeRendererInterface, ConfigurationAwareInterface
 {
     /** @psalm-readonly-allow-private-mutation */
     private ConfigurationInterface $config;

--- a/src/Renderer/Block/IndentedCodeRenderer.php
+++ b/src/Renderer/Block/IndentedCodeRenderer.php
@@ -9,7 +9,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class IndentedCodeRenderer implements NodeRendererInterface
+final class IndentedCodeRenderer implements NodeRendererInterface
 {
     /**
      * @param IndentedCode $node

--- a/src/Renderer/Block/ListBlockRenderer.php
+++ b/src/Renderer/Block/ListBlockRenderer.php
@@ -8,7 +8,7 @@ use League\CommonMark\Extension\CommonMark\Node\Block\ListBlock;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 
-class ListBlockRenderer implements \League\CommonMark\Renderer\NodeRendererInterface
+final class ListBlockRenderer implements \League\CommonMark\Renderer\NodeRendererInterface
 {
     /**
      * @param ListBlock $node
@@ -27,9 +27,7 @@ class ListBlockRenderer implements \League\CommonMark\Renderer\NodeRendererInter
         $content = explode("\n", $content);
 
         if ($listData->type === ListBlock::TYPE_BULLET) {
-            $content = array_map(function ($item) {
-                return "- {$item}";
-            }, $content);
+            $content = array_map(fn($item) => "- {$item}", $content);
         }
 
         if ($listData->type === ListBlock::TYPE_ORDERED) {

--- a/src/Renderer/Block/ListItemRenderer.php
+++ b/src/Renderer/Block/ListItemRenderer.php
@@ -10,7 +10,7 @@ use League\CommonMark\Node\Block\Paragraph;
 use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 
-class ListItemRenderer implements \League\CommonMark\Renderer\NodeRendererInterface
+final class ListItemRenderer implements \League\CommonMark\Renderer\NodeRendererInterface
 {
     /**
      * @param ListItem $node
@@ -19,16 +19,16 @@ class ListItemRenderer implements \League\CommonMark\Renderer\NodeRendererInterf
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
     {
         ListItem::assertInstanceOf($node);
 
         $contents = $childRenderer->renderNodes($node->children());
-        if (\substr($contents, 0, 1) === '<' && ! $this->startsTaskListItem($node)) {
+        if (str_starts_with($contents, '<') && ! $this->startsTaskListItem($node)) {
             $contents = "\n" . $contents;
         }
 
-        if (\substr($contents, -1, 1) === '>') {
+        if (str_ends_with($contents, '>')) {
             $contents .= "\n";
         }
 

--- a/src/Renderer/Block/ParagraphRenderer.php
+++ b/src/Renderer/Block/ParagraphRenderer.php
@@ -10,7 +10,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class ParagraphRenderer implements NodeRendererInterface
+final class ParagraphRenderer implements NodeRendererInterface
 {
     /**
      * @param Paragraph $node
@@ -19,7 +19,7 @@ class ParagraphRenderer implements NodeRendererInterface
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
     {
         Paragraph::assertInstanceOf($node);
 

--- a/src/Renderer/Block/ThematicBreakRenderer.php
+++ b/src/Renderer/Block/ThematicBreakRenderer.php
@@ -9,7 +9,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class ThematicBreakRenderer implements NodeRendererInterface
+final class ThematicBreakRenderer implements NodeRendererInterface
 {
     /**
      * @param ThematicBreak $node

--- a/src/Renderer/Inline/CodeRenderer.php
+++ b/src/Renderer/Inline/CodeRenderer.php
@@ -9,7 +9,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class CodeRenderer implements NodeRendererInterface
+final class CodeRenderer implements NodeRendererInterface
 {
     /**
      * @param Code $node

--- a/src/Renderer/Inline/EmphasisRenderer.php
+++ b/src/Renderer/Inline/EmphasisRenderer.php
@@ -11,7 +11,7 @@ use League\CommonMark\Renderer\NodeRendererInterface;
 use League\Config\ConfigurationAwareInterface;
 use League\Config\ConfigurationInterface;
 
-class EmphasisRenderer implements NodeRendererInterface, ConfigurationAwareInterface
+final class EmphasisRenderer implements NodeRendererInterface, ConfigurationAwareInterface
 {
     /** @psalm-readonly-allow-private-mutation */
     private ConfigurationInterface $config;
@@ -28,7 +28,7 @@ class EmphasisRenderer implements NodeRendererInterface, ConfigurationAwareInter
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
     {
         Emphasis::assertInstanceOf($node);
 

--- a/src/Renderer/Inline/HtmlInlineRenderer.php
+++ b/src/Renderer/Inline/HtmlInlineRenderer.php
@@ -12,7 +12,7 @@ use League\CommonMark\Util\HtmlFilter;
 use League\Config\ConfigurationAwareInterface;
 use League\Config\ConfigurationInterface;
 
-class HtmlInlineRenderer implements NodeRendererInterface, ConfigurationAwareInterface
+final class HtmlInlineRenderer implements NodeRendererInterface, ConfigurationAwareInterface
 {
     /** @psalm-readonly-allow-private-mutation */
     private ConfigurationInterface $config;

--- a/src/Renderer/Inline/ImageRenderer.php
+++ b/src/Renderer/Inline/ImageRenderer.php
@@ -12,7 +12,7 @@ use League\CommonMark\Util\RegexHelper;
 use League\Config\ConfigurationAwareInterface;
 use League\Config\ConfigurationInterface;
 
-class ImageRenderer implements NodeRendererInterface, ConfigurationAwareInterface
+final class ImageRenderer implements NodeRendererInterface, ConfigurationAwareInterface
 {
     /** @psalm-readonly-allow-private-mutation */
     private ConfigurationInterface $config;

--- a/src/Renderer/Inline/LinkRenderer.php
+++ b/src/Renderer/Inline/LinkRenderer.php
@@ -12,7 +12,7 @@ use League\CommonMark\Util\RegexHelper;
 use League\Config\ConfigurationAwareInterface;
 use League\Config\ConfigurationInterface;
 
-class LinkRenderer implements NodeRendererInterface, ConfigurationAwareInterface
+final class LinkRenderer implements NodeRendererInterface, ConfigurationAwareInterface
 {
     /** @psalm-readonly-allow-private-mutation */
     private ConfigurationInterface $config;
@@ -24,7 +24,7 @@ class LinkRenderer implements NodeRendererInterface, ConfigurationAwareInterface
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
     {
         Link::assertInstanceOf($node);
 

--- a/src/Renderer/Inline/NewlineRenderer.php
+++ b/src/Renderer/Inline/NewlineRenderer.php
@@ -10,7 +10,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Renderer\Inline {
     use League\Config\ConfigurationAwareInterface;
     use League\Config\ConfigurationInterface;
 
-    class NewlineRenderer implements NodeRendererInterface, ConfigurationAwareInterface
+    final class NewlineRenderer implements NodeRendererInterface, ConfigurationAwareInterface
     {
         /** @psalm-readonly-allow-private-mutation */
         private ConfigurationInterface $config;

--- a/src/Renderer/Inline/StrongRenderer.php
+++ b/src/Renderer/Inline/StrongRenderer.php
@@ -11,7 +11,7 @@ use League\CommonMark\Renderer\NodeRendererInterface;
 use League\Config\ConfigurationAwareInterface;
 use League\Config\ConfigurationInterface;
 
-class StrongRenderer implements NodeRendererInterface, ConfigurationAwareInterface
+final class StrongRenderer implements NodeRendererInterface, ConfigurationAwareInterface
 {
     /** @psalm-readonly-allow-private-mutation */
     private ConfigurationInterface $config;

--- a/src/Renderer/Inline/TaskListItemMarkerRenderer.php
+++ b/src/Renderer/Inline/TaskListItemMarkerRenderer.php
@@ -9,7 +9,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class TaskListItemMarkerRenderer implements NodeRendererInterface
+final class TaskListItemMarkerRenderer implements NodeRendererInterface
 {
     /**
      * @param TaskListItemMarker $node
@@ -18,7 +18,7 @@ class TaskListItemMarkerRenderer implements NodeRendererInterface
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
     {
         return sprintf('[%s]', $node->isChecked() ? 'x' : ' ');
     }

--- a/src/Renderer/Inline/TextRenderer.php
+++ b/src/Renderer/Inline/TextRenderer.php
@@ -9,7 +9,7 @@ use League\CommonMark\Node\Node;
 use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class TextRenderer implements NodeRendererInterface
+final class TextRenderer implements NodeRendererInterface
 {
     /**
      * @param Text $node
@@ -18,7 +18,7 @@ class TextRenderer implements NodeRendererInterface
      *
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): string
     {
         Text::assertInstanceOf($node);
 

--- a/src/Renderer/MarkdownRenderer.php
+++ b/src/Renderer/MarkdownRenderer.php
@@ -16,16 +16,10 @@ use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\MarkdownRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
-class MarkdownRenderer implements ChildNodeRendererInterface, MarkdownRendererInterface
+final class MarkdownRenderer implements ChildNodeRendererInterface, MarkdownRendererInterface
 {
-    /**
-     * @var Environment|Environment
-     */
-    private $environment;
-
-    public function __construct(Environment $environment)
+    public function __construct(private Environment $environment)
     {
-        $this->environment = $environment;
     }
 
     public function renderDocument(Document $document): RenderedContentInterface
@@ -41,13 +35,11 @@ class MarkdownRenderer implements ChildNodeRendererInterface, MarkdownRendererIn
     }
 
     /**
-     * @return \Stringable|string
-     *
      * @throws \RuntimeException
      */
-    private function renderNode(Node $node)
+    private function renderNode(Node $node): \Stringable|string
     {
-        $renderers = $this->environment->getRenderersForClass(\get_class($node));
+        $renderers = $this->environment->getRenderersForClass($node::class);
 
         foreach ($renderers as $renderer) {
             \assert($renderer instanceof NodeRendererInterface);
@@ -56,7 +48,7 @@ class MarkdownRenderer implements ChildNodeRendererInterface, MarkdownRendererIn
             }
         }
 
-        throw new \RuntimeException('Unable to find corresponding renderer for node type ' . \get_class($node));
+        throw new \RuntimeException('Unable to find corresponding renderer for node type ' . $node::class);
     }
 
     public function renderNodes(iterable $nodes): string

--- a/src/Renderer/MarkdownRenderer.php
+++ b/src/Renderer/MarkdownRenderer.php
@@ -21,7 +21,7 @@ use League\CommonMark\Renderer\NodeRendererInterface;
  */
 final class MarkdownRenderer implements ChildNodeRendererInterface, MarkdownRendererInterface
 {
-    public function __construct(private Environment $environment)
+    public function __construct(private readonly Environment $environment)
     {
     }
 

--- a/src/Renderer/MarkdownRenderer.php
+++ b/src/Renderer/MarkdownRenderer.php
@@ -16,6 +16,9 @@ use League\CommonMark\Renderer\ChildNodeRendererInterface;
 use League\CommonMark\Renderer\MarkdownRendererInterface;
 use League\CommonMark\Renderer\NodeRendererInterface;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 final class MarkdownRenderer implements ChildNodeRendererInterface, MarkdownRendererInterface
 {
     public function __construct(private Environment $environment)

--- a/tests/MarkdownRendererExtensionTest.php
+++ b/tests/MarkdownRendererExtensionTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\MarkdownRenderer;
 
-class MarkdownRendererExtensionTest extends TestCase
+final class MarkdownRendererExtensionTest extends TestCase
 {
     /**
      * @dataProvider getTestData
@@ -31,7 +31,7 @@ class MarkdownRendererExtensionTest extends TestCase
     /**
      * @return iterable<array<mixed>>
      */
-    public function getTestData(): iterable
+    public function getTestData(): \Iterator
     {
         yield ['*Emphasis*', [], "*Emphasis*\n"];
         yield ['**Strong**', [], "**Strong**\n"];

--- a/tests/MarkdownRendererExtensionTest.php
+++ b/tests/MarkdownRendererExtensionTest.php
@@ -6,6 +6,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests;
 
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Parser\MarkdownParser;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\MarkdownRenderer;
@@ -13,10 +14,9 @@ use Wnx\CommonmarkMarkdownRenderer\Renderer\MarkdownRenderer;
 final class MarkdownRendererExtensionTest extends TestCase
 {
     /**
-     * @dataProvider getTestData
-     *
      * @param array<string, mixed> $config
      */
+    #[DataProvider('getTestData')]
     public function test_markdown_renderer_extension_works(string $markdown, array $config, string $expected): void
     {
         $environment = new Environment($config);
@@ -31,7 +31,7 @@ final class MarkdownRendererExtensionTest extends TestCase
     /**
      * @return iterable<array<mixed>>
      */
-    public function getTestData(): \Iterator
+    public static function getTestData(): \Iterator
     {
         yield ['*Emphasis*', [], "*Emphasis*\n"];
         yield ['**Strong**', [], "**Strong**\n"];

--- a/tests/Renderer/Block/BlockQuoteRendererTest.php
+++ b/tests/Renderer/Block/BlockQuoteRendererTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\BlockQuoteRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class BlockQuoteRendererTest extends TestCase
+final class BlockQuoteRendererTest extends TestCase
 {
     private BlockQuoteRenderer $renderer;
 
@@ -19,7 +19,7 @@ class BlockQuoteRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_block_quote()
+    public function it_renders_block_quote(): void
     {
         $block = new BlockQuote();
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/Renderer/Block/BlockQuoteRendererTest.php
+++ b/tests/Renderer/Block/BlockQuoteRendererTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\BlockQuoteRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -18,7 +19,7 @@ final class BlockQuoteRendererTest extends TestCase
         $this->renderer = new BlockQuoteRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_block_quote(): void
     {
         $block = new BlockQuote();

--- a/tests/Renderer/Block/DocumentRendererTest.php
+++ b/tests/Renderer/Block/DocumentRendererTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
 use League\CommonMark\Node\Block\Document;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\DocumentRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -18,7 +19,7 @@ final class DocumentRendererTest extends TestCase
         $this->renderer = new DocumentRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_document(): void
     {
         $block = new Document();

--- a/tests/Renderer/Block/DocumentRendererTest.php
+++ b/tests/Renderer/Block/DocumentRendererTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\DocumentRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class DocumentRendererTest extends TestCase
+final class DocumentRendererTest extends TestCase
 {
     private DocumentRenderer $renderer;
 
@@ -19,7 +19,7 @@ class DocumentRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_document()
+    public function it_renders_document(): void
     {
         $block = new Document();
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/Renderer/Block/FencedCodeRendererTest.php
+++ b/tests/Renderer/Block/FencedCodeRendererTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\FencedCodeRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class FencedCodeRendererTest extends TestCase
+final class FencedCodeRendererTest extends TestCase
 {
     private FencedCodeRenderer $renderer;
 

--- a/tests/Renderer/Block/FencedCodeRendererTest.php
+++ b/tests/Renderer/Block/FencedCodeRendererTest.php
@@ -6,6 +6,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Node\Block\Document;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\FencedCodeRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -19,7 +20,7 @@ final class FencedCodeRendererTest extends TestCase
         $this->renderer = new FencedCodeRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_fenced_code(): void
     {
         $document = new Document();

--- a/tests/Renderer/Block/HeadingRendererTest.php
+++ b/tests/Renderer/Block/HeadingRendererTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\HeadingRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -18,7 +19,7 @@ final class HeadingRendererTest extends TestCase
         $this->renderer = new HeadingRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_heading(): void
     {
         $block = new Heading(1);

--- a/tests/Renderer/Block/HeadingRendererTest.php
+++ b/tests/Renderer/Block/HeadingRendererTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\HeadingRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class HeadingRendererTest extends TestCase
+final class HeadingRendererTest extends TestCase
 {
     private HeadingRenderer $renderer;
 
@@ -19,7 +19,7 @@ class HeadingRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_heading()
+    public function it_renders_heading(): void
     {
         $block = new Heading(1);
 

--- a/tests/Renderer/Block/HtmlBlockRendererTest.php
+++ b/tests/Renderer/Block/HtmlBlockRendererTest.php
@@ -7,6 +7,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Block\HtmlBlock;
 use League\Config\ConfigurationInterface;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\HtmlBlockRenderer;
@@ -22,7 +23,7 @@ final class HtmlBlockRendererTest extends TestCase
         $this->renderer->setConfiguration($this->createConfiguration());
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_paragraph(): void
     {
         $block = new HtmlBlock(HtmlBlock::TYPE_2_COMMENT);

--- a/tests/Renderer/Block/HtmlBlockRendererTest.php
+++ b/tests/Renderer/Block/HtmlBlockRendererTest.php
@@ -12,7 +12,7 @@ use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\HtmlBlockRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class HtmlBlockRendererTest extends TestCase
+final class HtmlBlockRendererTest extends TestCase
 {
     private HtmlBlockRenderer $renderer;
 
@@ -23,7 +23,7 @@ class HtmlBlockRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_paragraph()
+    public function it_renders_paragraph(): void
     {
         $block = new HtmlBlock(HtmlBlock::TYPE_2_COMMENT);
         $block->setLiteral("<!-- This is a comment -->");

--- a/tests/Renderer/Block/IndentedCodeRendererTest.php
+++ b/tests/Renderer/Block/IndentedCodeRendererTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\IndentedCodeRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class IndentedCodeRendererTest extends TestCase
+final class IndentedCodeRendererTest extends TestCase
 {
     private IndentedCodeRenderer $renderer;
 
@@ -20,7 +20,7 @@ class IndentedCodeRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_indented_code_renderer()
+    public function it_renders_indented_code_renderer(): void
     {
         $document = new Document();
 

--- a/tests/Renderer/Block/IndentedCodeRendererTest.php
+++ b/tests/Renderer/Block/IndentedCodeRendererTest.php
@@ -6,6 +6,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
 use League\CommonMark\Node\Block\Document;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\IndentedCodeRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -19,7 +20,7 @@ final class IndentedCodeRendererTest extends TestCase
         $this->renderer = new IndentedCodeRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_indented_code_renderer(): void
     {
         $document = new Document();

--- a/tests/Renderer/Block/ListBlockRendererTest.php
+++ b/tests/Renderer/Block/ListBlockRendererTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\ListBlockRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class ListBlockRendererTest extends TestCase
+final class ListBlockRendererTest extends TestCase
 {
     private ListBlockRenderer $renderer;
 
@@ -20,7 +20,7 @@ class ListBlockRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_ordered_list_block()
+    public function it_renders_ordered_list_block(): void
     {
         $data = new ListData();
         $data->type = ListBlock::TYPE_ORDERED;
@@ -37,7 +37,7 @@ class ListBlockRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_unordered_list_block()
+    public function it_renders_unordered_list_block(): void
     {
         $data = new ListData();
         $data->type = ListBlock::TYPE_BULLET;

--- a/tests/Renderer/Block/ListBlockRendererTest.php
+++ b/tests/Renderer/Block/ListBlockRendererTest.php
@@ -6,6 +6,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\ListBlock;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListData;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\ListBlockRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -19,7 +20,7 @@ final class ListBlockRendererTest extends TestCase
         $this->renderer = new ListBlockRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_ordered_list_block(): void
     {
         $data = new ListData();
@@ -36,7 +37,7 @@ final class ListBlockRendererTest extends TestCase
         $this->assertEquals("1. ::children::\n", $result);
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_unordered_list_block(): void
     {
         $data = new ListData();

--- a/tests/Renderer/Block/ListItemRendererTest.php
+++ b/tests/Renderer/Block/ListItemRendererTest.php
@@ -6,6 +6,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\ListData;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListItem;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\ListItemRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -19,7 +20,7 @@ final class ListItemRendererTest extends TestCase
         $this->renderer = new ListItemRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_unordered_list(): void
     {
         $block = new ListItem(new ListData());

--- a/tests/Renderer/Block/ListItemRendererTest.php
+++ b/tests/Renderer/Block/ListItemRendererTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\ListItemRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class ListItemRendererTest extends TestCase
+final class ListItemRendererTest extends TestCase
 {
     private ListItemRenderer $renderer;
 
@@ -20,7 +20,7 @@ class ListItemRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_unordered_list()
+    public function it_renders_unordered_list(): void
     {
         $block = new ListItem(new ListData());
         $block->data->set('attributes/id', 'foo');

--- a/tests/Renderer/Block/ParagraphRendererTest.php
+++ b/tests/Renderer/Block/ParagraphRendererTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\ParagraphRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class ParagraphRendererTest extends TestCase
+final class ParagraphRendererTest extends TestCase
 {
     private ParagraphRenderer $renderer;
 
@@ -19,7 +19,7 @@ class ParagraphRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_paragraph()
+    public function it_renders_paragraph(): void
     {
         $block = new Paragraph();
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/Renderer/Block/ParagraphRendererTest.php
+++ b/tests/Renderer/Block/ParagraphRendererTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
 use League\CommonMark\Node\Block\Paragraph;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\ParagraphRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -18,7 +19,7 @@ final class ParagraphRendererTest extends TestCase
         $this->renderer = new ParagraphRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_paragraph(): void
     {
         $block = new Paragraph();

--- a/tests/Renderer/Block/ThematicBreakRendererTest.php
+++ b/tests/Renderer/Block/ThematicBreakRendererTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\ThematicBreakRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class ThematicBreakRendererTest extends TestCase
+final class ThematicBreakRendererTest extends TestCase
 {
     private ThematicBreakRenderer $renderer;
 
@@ -19,7 +19,7 @@ class ThematicBreakRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_thematic_break()
+    public function it_renders_thematic_break(): void
     {
         $block = new ThematicBreak();
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/Renderer/Block/ThematicBreakRendererTest.php
+++ b/tests/Renderer/Block/ThematicBreakRendererTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\ThematicBreakRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -18,7 +19,7 @@ final class ThematicBreakRendererTest extends TestCase
         $this->renderer = new ThematicBreakRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_thematic_break(): void
     {
         $block = new ThematicBreak();

--- a/tests/Renderer/Inline/EmphasisRendererTest.php
+++ b/tests/Renderer/Inline/EmphasisRendererTest.php
@@ -7,6 +7,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Inline;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Emphasis;
 use League\Config\ConfigurationInterface;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\EmphasisRenderer;
@@ -22,7 +23,7 @@ final class EmphasisRendererTest extends TestCase
         $this->renderer->setConfiguration($this->createConfiguration());
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_emphasis(): void
     {
         $block = new Emphasis();

--- a/tests/Renderer/Inline/EmphasisRendererTest.php
+++ b/tests/Renderer/Inline/EmphasisRendererTest.php
@@ -12,7 +12,7 @@ use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\EmphasisRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class EmphasisRendererTest extends TestCase
+final class EmphasisRendererTest extends TestCase
 {
     private EmphasisRenderer $renderer;
 
@@ -23,7 +23,7 @@ class EmphasisRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_emphasis()
+    public function it_renders_emphasis(): void
     {
         $block = new Emphasis();
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/Renderer/Inline/HtmlInlineRendererTest.php
+++ b/tests/Renderer/Inline/HtmlInlineRendererTest.php
@@ -12,7 +12,7 @@ use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\HtmlInlineRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class HtmlInlineRendererTest extends TestCase
+final class HtmlInlineRendererTest extends TestCase
 {
     private HtmlInlineRenderer $renderer;
 
@@ -23,7 +23,7 @@ class HtmlInlineRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_inline_html()
+    public function it_renders_inline_html(): void
     {
         $block = new HtmlInline("<h1>Test</h1>");
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/Renderer/Inline/HtmlInlineRendererTest.php
+++ b/tests/Renderer/Inline/HtmlInlineRendererTest.php
@@ -7,6 +7,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Inline;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Inline\HtmlInline;
 use League\Config\ConfigurationInterface;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\HtmlInlineRenderer;
@@ -22,7 +23,7 @@ final class HtmlInlineRendererTest extends TestCase
         $this->renderer->setConfiguration($this->createConfiguration());
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_inline_html(): void
     {
         $block = new HtmlInline("<h1>Test</h1>");

--- a/tests/Renderer/Inline/LinkRendererTest.php
+++ b/tests/Renderer/Inline/LinkRendererTest.php
@@ -22,7 +22,7 @@ final class LinkRendererTest extends TestCase
         $this->renderer->setConfiguration($this->createConfiguration());
     }
 
-    /** @test */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function it_renders_link(): void
     {
         $inline = new Link('http://example.com/foo.html', '::label::', '::title::');

--- a/tests/Renderer/Inline/LinkRendererTest.php
+++ b/tests/Renderer/Inline/LinkRendererTest.php
@@ -12,7 +12,7 @@ use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\LinkRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class LinkRendererTest extends TestCase
+final class LinkRendererTest extends TestCase
 {
     private LinkRenderer $renderer;
 
@@ -23,7 +23,7 @@ class LinkRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_link()
+    public function it_renders_link(): void
     {
         $inline = new Link('http://example.com/foo.html', '::label::', '::title::');
         $inline->data->set('attributes', ['id' => '::id::', 'title' => '::title2::', 'href' => '::href2::']);

--- a/tests/Renderer/Inline/NewlineRendererTest.php
+++ b/tests/Renderer/Inline/NewlineRendererTest.php
@@ -12,7 +12,7 @@ use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\NewlineRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class NewlineRendererTest extends TestCase
+final class NewlineRendererTest extends TestCase
 {
     private NewlineRenderer $renderer;
 
@@ -22,7 +22,7 @@ class NewlineRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_hardbreak_new_line()
+    public function it_renders_hardbreak_new_line(): void
     {
         $inline = new Newline(Newline::HARDBREAK);
         $fakeRenderer = new FakeChildNodeRenderer();
@@ -34,7 +34,7 @@ class NewlineRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_softbreak_new_line()
+    public function it_renders_softbreak_new_line(): void
     {
         $inline = new Newline(Newline::SOFTBREAK);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/Renderer/Inline/NewlineRendererTest.php
+++ b/tests/Renderer/Inline/NewlineRendererTest.php
@@ -7,6 +7,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Inline;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Node\Inline\Newline;
 use League\Config\ConfigurationInterface;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\NewlineRenderer;
@@ -21,7 +22,7 @@ final class NewlineRendererTest extends TestCase
         $this->renderer = new NewlineRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_hardbreak_new_line(): void
     {
         $inline = new Newline(Newline::HARDBREAK);
@@ -33,7 +34,7 @@ final class NewlineRendererTest extends TestCase
         $this->assertEquals("\n", $result);
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_softbreak_new_line(): void
     {
         $inline = new Newline(Newline::SOFTBREAK);

--- a/tests/Renderer/Inline/StrongRendererTest.php
+++ b/tests/Renderer/Inline/StrongRendererTest.php
@@ -12,7 +12,7 @@ use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\StrongRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class StrongRendererTest extends TestCase
+final class StrongRendererTest extends TestCase
 {
     private StrongRenderer $renderer;
 
@@ -23,7 +23,7 @@ class StrongRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_strong()
+    public function it_renders_strong(): void
     {
         $block = new Strong();
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/Renderer/Inline/StrongRendererTest.php
+++ b/tests/Renderer/Inline/StrongRendererTest.php
@@ -7,6 +7,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Inline;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Strong;
 use League\Config\ConfigurationInterface;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\StrongRenderer;
@@ -22,7 +23,7 @@ final class StrongRendererTest extends TestCase
         $this->renderer->setConfiguration($this->createConfiguration());
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_strong(): void
     {
         $block = new Strong();

--- a/tests/Renderer/Inline/TaskListItemMarkerRendererTest.php
+++ b/tests/Renderer/Inline/TaskListItemMarkerRendererTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\TaskListItemMarkerRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class TaskListItemMarkerRendererTest extends TestCase
+final class TaskListItemMarkerRendererTest extends TestCase
 {
     private TaskListItemMarkerRenderer $renderer;
 
@@ -19,7 +19,7 @@ class TaskListItemMarkerRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_unchecked_task_list_item()
+    public function it_renders_unchecked_task_list_item(): void
     {
         $node = new TaskListItemMarker(false);
         $fakeRenderer = new FakeChildNodeRenderer();
@@ -31,7 +31,7 @@ class TaskListItemMarkerRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_checked_task_list_item()
+    public function it_renders_checked_task_list_item(): void
     {
         $node = new TaskListItemMarker(true);
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/Renderer/Inline/TaskListItemMarkerRendererTest.php
+++ b/tests/Renderer/Inline/TaskListItemMarkerRendererTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Inline;
 
 use League\CommonMark\Extension\TaskList\TaskListItemMarker;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\TaskListItemMarkerRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -18,7 +19,7 @@ final class TaskListItemMarkerRendererTest extends TestCase
         $this->renderer = new TaskListItemMarkerRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_unchecked_task_list_item(): void
     {
         $node = new TaskListItemMarker(false);
@@ -30,7 +31,7 @@ final class TaskListItemMarkerRendererTest extends TestCase
         $this->assertEquals("[ ]", $result);
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_checked_task_list_item(): void
     {
         $node = new TaskListItemMarker(true);

--- a/tests/Renderer/Inline/TextRendererTest.php
+++ b/tests/Renderer/Inline/TextRendererTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Inline;
 
 use League\CommonMark\Node\Inline\Text;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\TextRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
@@ -18,7 +19,7 @@ final class TextRendererTest extends TestCase
         $this->renderer = new TextRenderer();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_paragraph(): void
     {
         $block = new Text('Foo Bar');

--- a/tests/Renderer/Inline/TextRendererTest.php
+++ b/tests/Renderer/Inline/TextRendererTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Inline\TextRenderer;
 use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
 
-class TextRendererTest extends TestCase
+final class TextRendererTest extends TestCase
 {
     private TextRenderer $renderer;
 
@@ -19,7 +19,7 @@ class TextRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_paragraph()
+    public function it_renders_paragraph(): void
     {
         $block = new Text('Foo Bar');
         $fakeRenderer = new FakeChildNodeRenderer();

--- a/tests/Renderer/MarkdownRendererTest.php
+++ b/tests/Renderer/MarkdownRendererTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\MarkdownRenderer;
 
-class MarkdownRendererTest extends TestCase
+final class MarkdownRendererTest extends TestCase
 {
     private MarkdownParser $parser;
 
@@ -26,7 +26,7 @@ class MarkdownRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_ast_to_markdown()
+    public function it_renders_ast_to_markdown(): void
     {
         $document = $this->parser->parse("# Hello World");
 
@@ -37,7 +37,7 @@ class MarkdownRendererTest extends TestCase
     }
 
     /** @test */
-    public function it_parses_and_renders_kitchen_sink()
+    public function it_parses_and_renders_kitchen_sink(): void
     {
         $contentKitchenSink = file_get_contents(__DIR__ . '/../stubs/kitchen-sink.md');
 

--- a/tests/Renderer/MarkdownRendererTest.php
+++ b/tests/Renderer/MarkdownRendererTest.php
@@ -6,6 +6,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer;
 
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Parser\MarkdownParser;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\MarkdownRenderer;
@@ -25,7 +26,7 @@ final class MarkdownRendererTest extends TestCase
         $this->renderer = new MarkdownRenderer($environment);
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_ast_to_markdown(): void
     {
         $document = $this->parser->parse("# Hello World");
@@ -36,7 +37,7 @@ final class MarkdownRendererTest extends TestCase
         $this->assertEquals("# Hello World\n", $result);
     }
 
-    /** @test */
+    #[Test]
     public function it_parses_and_renders_kitchen_sink(): void
     {
         $contentKitchenSink = file_get_contents(__DIR__ . '/../stubs/kitchen-sink.md');


### PR DESCRIPTION
Hello again,

there are more changes coming up from my side, as I use your lib in one of my tools, so I figured I might as well do some maintenance chores. This PR includes:

- Introduce Rector and update codebase to PHP8 code standards
- Update Psalm to ^5.7 and increase error level (now down to 3)
- Update PHPUnit to ^10.0 and refactor test code to current standards (attributes instead of docblock annotations mainly)

Running Rector as GitHub action would also be a nice addition to your workflows, but I haven't done that (yet).