### PR TITLE
Render fenced block how it wants to be rendered

### DIFF
--- a/src/Renderer/Block/FencedCodeRenderer.php
+++ b/src/Renderer/Block/FencedCodeRenderer.php
@@ -32,11 +32,13 @@ final class FencedCodeRenderer implements NodeRendererInterface
         }
 
         $content = $node->getLiteral();
+        $delimiter = str_repeat($node->getChar(), $node->getLength());
+        $offset = str_repeat(' ', $node->getOffset());
 
         return <<<TXT
-        ```{$language}
-        {$content}
-        ```
+        {$offset}{$delimiter}{$language}
+        {$offset}{$content}
+        {$offset}{$delimiter}
         TXT;
     }
 }

--- a/tests/Renderer/Block/FencedCodeRendererTest.php
+++ b/tests/Renderer/Block/FencedCodeRendererTest.php
@@ -6,6 +6,7 @@ namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Node\Block\Document;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\FencedCodeRenderer;
@@ -21,11 +22,12 @@ final class FencedCodeRendererTest extends TestCase
     }
 
     #[Test]
-    public function it_renders_fenced_code(): void
+    #[DataProvider('provide_fenced_code')]
+    public function it_renders_fenced_code(array $fencedArgs, string $expected): void
     {
         $document = new Document();
 
-        $block = new FencedCode(3, '~', 0);
+        $block = new FencedCode(...$fencedArgs);
         $block->setInfo('php');
         $block->setLiteral('echo "hello world!";');
         $block->data->set('attributes', ['id' => 'foo', 'class' => 'bar']);
@@ -36,10 +38,36 @@ final class FencedCodeRendererTest extends TestCase
 
         $result = $this->renderer->render($block, $fakeRenderer);
 
-        $this->assertEquals(<<<TXT
-        ```php
-        echo "hello world!";
-        ```
-        TXT, $result);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function provide_fenced_code(): array
+    {
+        return [
+            'tilde as char' => [
+                'fencedArgs' => [3, '~', 0],
+                'expected' => <<<TXT
+                ~~~php
+                echo "hello world!";
+                ~~~
+                TXT
+            ],
+            'backtick as char' => [
+                'fencedArgs' => [3, '`', 0],
+                'expected' => <<<TXT
+                ```php
+                echo "hello world!";
+                ```
+                TXT
+            ],
+            'offset and >3 chars' => [
+                'fencedArgs' => [5, '`', 2],
+                'expected' => <<<TXT
+                  `````php
+                  echo "hello world!";
+                  `````
+                TXT
+            ],
+        ];
     }
 }


### PR DESCRIPTION
The `FencedCode` class stores information about what delimiter character should be used, how many should be used, and what the indent offset is for the block.


This is important information to retain and re-use, since a fenced block indicating markdown might look like:
`````
````
This is how a fenced block looks:
```php
<?
// some code here
```
````
`````

In this example, the four backticks are used to denote our actual fenced code block, and the three backticks are part of the literal code inside the block. Without retaining the information about how many delimiter characters to use, you might end up closing the block early.


The offset is useful because you might have a fenced code block inside a list like so:
````
- some random thing
  ```
  This fenced block is part of the list item, so its indent is important to avoid cancelling the list and starting a new one
  ```
- another thing
````

Finally, reusing the original delimiter character is useful. Tildes are a valid character to use. If someone uses this library to modify part of their markdown AST and then write back the file, it would be nice to retain their original code block delimiters so they don't have to go swapping them back to what they used to be.

## NOTE
There's no issues in this repo so I can't open an issue about it - but there are other nodes as well (such as list items) which tell you what character should be used to render it. This library would be so much more useful if it retained the original options. If your intention with this renderer is that it normalises things, then having a configuration option to use the originals instead of normalisation would be useful.