### PR TITLE
Update Strong and Emphasis Renderers to use settings available in AST Node

### DIFF
--- a/src/Renderer/Inline/EmphasisRenderer.php
+++ b/src/Renderer/Inline/EmphasisRenderer.php
@@ -38,6 +38,13 @@ final class EmphasisRenderer implements NodeRendererInterface, ConfigurationAwar
             return "*{$content}*";
         }
 
-        return "_{$content}_";
+        if ($this->config->get('commonmark/use_underscore')) {
+            return "_{$content}_";
+        }
+
+        $openingDelimiter = $node->getOpeningDelimiter();
+        $closingDelimiter = $node->getClosingDelimiter();
+
+        return "$openingDelimiter{$content}$closingDelimiter";
     }
 }

--- a/src/Renderer/Inline/StrongRenderer.php
+++ b/src/Renderer/Inline/StrongRenderer.php
@@ -38,6 +38,13 @@ final class StrongRenderer implements NodeRendererInterface, ConfigurationAwareI
             return "**{$content}**";
         }
 
-        return "__{$content}__";
+        if ($this->config->get('commonmark/use_underscore')) {
+            return "__{$content}__";
+        }
+
+        $openingDelimiter = $node->getOpeningDelimiter();
+        $closingDelimiter = $node->getClosingDelimiter();
+
+        return "$openingDelimiter{$content}$closingDelimiter";
     }
 }

--- a/tests/Renderer/Inline/EmphasisRendererTest.php
+++ b/tests/Renderer/Inline/EmphasisRendererTest.php
@@ -24,7 +24,7 @@ final class EmphasisRendererTest extends TestCase
     }
 
     #[Test]
-    public function it_renders_emphasis(): void
+    public function it_renders_emphasis_using_asterisk(): void
     {
         $block = new Emphasis();
         $fakeRenderer = new FakeChildNodeRenderer();
@@ -34,6 +34,45 @@ final class EmphasisRendererTest extends TestCase
 
         $this->assertIsString($result);
         $this->assertEquals('*::children::*', $result);
+    }
+
+    #[Test]
+    public function it_renders_emphasis_using_underscore(): void
+    {
+        $block = new Emphasis('_');
+        $fakeRenderer = new FakeChildNodeRenderer();
+        $fakeRenderer->pretendChildrenExist();
+
+        $this->renderer->setConfiguration($this->createConfiguration([
+            'commonmark' => [
+                'use_asterisk' => false,
+            ],
+        ]));
+
+        $result = $this->renderer->render($block, $fakeRenderer);
+
+        $this->assertIsString($result);
+        $this->assertEquals('_::children::_', $result);
+    }
+
+    #[Test]
+    public function it_renders_emphasis_with_whatever_delimiter_used(): void
+    {
+        $block = new Emphasis('$');
+        $fakeRenderer = new FakeChildNodeRenderer();
+        $fakeRenderer->pretendChildrenExist();
+
+        $this->renderer->setConfiguration($this->createConfiguration([
+            'commonmark' => [
+                'use_asterisk' => false,
+                'use_underscore' => false,
+            ],
+        ]));
+
+        $result = $this->renderer->render($block, $fakeRenderer);
+
+        $this->assertIsString($result);
+        $this->assertEquals('$::children::$', $result);
     }
 
     /**

--- a/tests/Renderer/Inline/StrongRendererTest.php
+++ b/tests/Renderer/Inline/StrongRendererTest.php
@@ -24,19 +24,6 @@ final class StrongRendererTest extends TestCase
     }
 
     #[Test]
-    public function it_renders_strong(): void
-    {
-        $block = new Strong();
-        $fakeRenderer = new FakeChildNodeRenderer();
-        $fakeRenderer->pretendChildrenExist();
-
-        $result = $this->renderer->render($block, $fakeRenderer);
-
-        $this->assertIsString($result);
-        $this->assertEquals('**::children::**', $result);
-    }
-
-    #[Test]
     public function it_renders_strong_with_asterisks(): void
     {
         $block = new Strong();
@@ -71,7 +58,7 @@ final class StrongRendererTest extends TestCase
     #[Test]
     public function it_renders_strong_using_whatever_delimiter_used_in_the_original(): void
     {
-        $block = new Strong('__');
+        $block = new Strong('$$');
         $fakeRenderer = new FakeChildNodeRenderer();
         $fakeRenderer->pretendChildrenExist();
 
@@ -85,7 +72,7 @@ final class StrongRendererTest extends TestCase
         $result = $this->renderer->render($block, $fakeRenderer);
 
         $this->assertIsString($result);
-        $this->assertEquals('__::children::__', $result);
+        $this->assertEquals('$$::children::$$', $result);
     }
 
     /**

--- a/tests/Renderer/Inline/StrongRendererTest.php
+++ b/tests/Renderer/Inline/StrongRendererTest.php
@@ -36,6 +36,58 @@ final class StrongRendererTest extends TestCase
         $this->assertEquals('**::children::**', $result);
     }
 
+    #[Test]
+    public function it_renders_strong_with_asterisks(): void
+    {
+        $block = new Strong();
+        $fakeRenderer = new FakeChildNodeRenderer();
+        $fakeRenderer->pretendChildrenExist();
+
+        $result = $this->renderer->render($block, $fakeRenderer);
+
+        $this->assertIsString($result);
+        $this->assertEquals('**::children::**', $result);
+    }
+
+    #[Test]
+    public function it_renders_strong_using_underscores_if_use_asterik_is_disabled(): void
+    {
+        $block = new Strong('__');
+        $fakeRenderer = new FakeChildNodeRenderer();
+        $fakeRenderer->pretendChildrenExist();
+
+        $this->renderer->setConfiguration($this->createConfiguration([
+            'commonmark' => [
+                'use_asterisk' => false,
+            ],
+        ]));
+
+        $result = $this->renderer->render($block, $fakeRenderer);
+
+        $this->assertIsString($result);
+        $this->assertEquals('__::children::__', $result);
+    }
+
+    #[Test]
+    public function it_renders_strong_using_whatever_delimiter_used_in_the_original(): void
+    {
+        $block = new Strong('__');
+        $fakeRenderer = new FakeChildNodeRenderer();
+        $fakeRenderer->pretendChildrenExist();
+
+        $this->renderer->setConfiguration($this->createConfiguration([
+            'commonmark' => [
+                'use_asterisk' => false,
+                'use_underscore' => false,
+            ],
+        ]));
+
+        $result = $this->renderer->render($block, $fakeRenderer);
+
+        $this->assertIsString($result);
+        $this->assertEquals('__::children::__', $result);
+    }
+
     /**
      * @param array<string, mixed> $values
      */

--- a/tests/stubs/kitchen-sink-expected.md
+++ b/tests/stubs/kitchen-sink-expected.md
@@ -25,3 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 *This Text is Italic*
 
 `\Class->getFoo()`
+
+- List Item A with `inline code`
+- List Item B

--- a/tests/stubs/kitchen-sink.md
+++ b/tests/stubs/kitchen-sink.md
@@ -25,3 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 *This Text is Italic*
 
 `\Class->getFoo()`
+
+- List Item A with `inline code`
+- List Item B


### PR DESCRIPTION
As mentioned in #10, some renderers ignored settings/properties that are available on each AST Node.

This PR fixes this by updating the renderers to use the available delimiters, depths, paddings and chars.