### PR TITLE
Fix list renderer to respect original content

### DIFF
--- a/src/Renderer/Block/ListBlockRenderer.php
+++ b/src/Renderer/Block/ListBlockRenderer.php
@@ -21,39 +21,9 @@ final class ListBlockRenderer implements \League\CommonMark\Renderer\NodeRendere
     {
         ListBlock::assertInstanceOf($node);
 
-        $listData = $node->getListData();
-
         $content = $childRenderer->renderNodes($node->children());
         $content = explode("\n", $content);
 
-        $content = array_map(fn ($item) => $this->replaceInternalLineBreakCharacter($item), $content);
-
-        if ($listData->type === ListBlock::TYPE_BULLET) {
-            $content = array_map(fn ($item) => "- {$item}", $content);
-        }
-
-        if ($listData->type === ListBlock::TYPE_ORDERED) {
-            $returnArray = [];
-            foreach ($content as $key => $value) {
-                $key++;
-                $returnArray[] = "{$key}. $value";
-            }
-
-            $content = $returnArray;
-        }
-
         return implode("\n", $content) . "\n";
-    }
-
-    /**
-     * Replace custom line break character with _native_ line breaks.
-     * Whitespace is added so that other Markdown clients correctly
-     * render the list and its line breaks.
-     * @param string $content
-     * @return string
-     */
-    private function replaceInternalLineBreakCharacter(string $content): string
-    {
-        return str_replace(ListItemRenderer::INLINE_LINE_BREAK, "   \n  ", $content);
     }
 }

--- a/tests/Renderer/Block/ListBlockRendererTest.php
+++ b/tests/Renderer/Block/ListBlockRendererTest.php
@@ -55,7 +55,7 @@ final class ListBlockRendererTest extends TestCase
 
         // Assert
         $this->assertIsString($result);
-        $this->assertEquals("1. List Item Value\n", $result);
+        $this->assertEquals("1. List Item Value\n   \n", $result);
     }
 
     #[Test]
@@ -85,6 +85,6 @@ final class ListBlockRendererTest extends TestCase
         $result = $this->renderer->render($block, $childRenderer);
 
         $this->assertIsString($result);
-        $this->assertEquals("- List Item Value\n", $result);
+        $this->assertEquals("- List Item Value\n  \n", $result);
     }
 }

--- a/tests/Renderer/Block/ListBlockRendererTest.php
+++ b/tests/Renderer/Block/ListBlockRendererTest.php
@@ -87,4 +87,44 @@ final class ListBlockRendererTest extends TestCase
         $this->assertIsString($result);
         $this->assertEquals("- List Item Value\n  \n", $result);
     }
+
+    #[Test]
+    public function it_renders_unordered_list_with_multiple_list_item_values_correctly(): void
+    {
+        // Build up Children
+        $data = new ListData();
+        $data->type = ListBlock::TYPE_BULLET;
+        $data->padding = 2;
+        $data->bulletChar = '-';
+
+        $listItem = new ListItem($data);
+
+        $paragraph = new Paragraph();
+        $paragraph->appendChild(new Text('List Item Value'));
+        $listItem->appendChild($paragraph);
+
+        $block = new ListBlock($data);
+        $block->appendChild($listItem);
+        $block->appendChild(clone $listItem);
+        $block->appendChild(clone $listItem);
+
+        // Build up Child Renderer
+        $environment = new Environment();
+        $environment->addExtension(new MarkdownRendererExtension());
+        $childRenderer = new MarkdownRenderer($environment);
+
+        // Render AST
+        $result = $this->renderer->render($block, $childRenderer);
+
+        $this->assertIsString($result);
+        $this->assertEquals(<<<'TXT'
+        - List Item Value
+          
+        - List Item Value
+          
+        - List Item Value
+          
+
+        TXT, $result);
+    }
 }

--- a/tests/Renderer/Block/ListBlockRendererTest.php
+++ b/tests/Renderer/Block/ListBlockRendererTest.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
+use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListBlock;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListData;
+use League\CommonMark\Extension\CommonMark\Node\Block\ListItem;
+use League\CommonMark\Node\Block\Paragraph;
+use League\CommonMark\Node\Inline\Text;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Wnx\CommonmarkMarkdownRenderer\MarkdownRendererExtension;
 use Wnx\CommonmarkMarkdownRenderer\Renderer\Block\ListBlockRenderer;
-use Wnx\CommonmarkMarkdownRenderer\Tests\Support\FakeChildNodeRenderer;
+use Wnx\CommonmarkMarkdownRenderer\Renderer\MarkdownRenderer;
 
 final class ListBlockRendererTest extends TestCase
 {
@@ -23,34 +28,63 @@ final class ListBlockRendererTest extends TestCase
     #[Test]
     public function it_renders_ordered_list_block(): void
     {
+        // Build up Children
         $data = new ListData();
         $data->type = ListBlock::TYPE_ORDERED;
-        $data->start = 0;
+        $data->start = 1;
+        $data->padding = 3;
+        $data->delimiter = 'period';
+        $data->bulletChar = '-';
+
+        $listItem = new ListItem($data);
+
+        $paragraph = new Paragraph();
+        $paragraph->appendChild(new Text('List Item Value'));
+        $listItem->appendChild($paragraph);
 
         $block = new ListBlock($data);
-        $fakeRenderer = new FakeChildNodeRenderer();
-        $fakeRenderer->pretendChildrenExist();
+        $block->appendChild($listItem);
 
-        $result = $this->renderer->render($block, $fakeRenderer);
+        // Build up Child Renderer
+        $environment = new Environment();
+        $environment->addExtension(new MarkdownRendererExtension());
+        $childRenderer = new MarkdownRenderer($environment);
 
+        // Render AST
+        $result = $this->renderer->render($block, $childRenderer);
+
+        // Assert
         $this->assertIsString($result);
-        $this->assertEquals("1. ::children::\n", $result);
+        $this->assertEquals("1. List Item Value\n", $result);
     }
 
     #[Test]
     public function it_renders_unordered_list_block(): void
     {
+        // Build up Children
         $data = new ListData();
         $data->type = ListBlock::TYPE_BULLET;
-        $data->start = 0;
+        $data->padding = 2;
+        $data->bulletChar = '-';
+
+        $listItem = new ListItem($data);
+
+        $paragraph = new Paragraph();
+        $paragraph->appendChild(new Text('List Item Value'));
+        $listItem->appendChild($paragraph);
 
         $block = new ListBlock($data);
-        $fakeRenderer = new FakeChildNodeRenderer();
-        $fakeRenderer->pretendChildrenExist();
+        $block->appendChild($listItem);
 
-        $result = $this->renderer->render($block, $fakeRenderer);
+        // Build up Child Renderer
+        $environment = new Environment();
+        $environment->addExtension(new MarkdownRendererExtension());
+        $childRenderer = new MarkdownRenderer($environment);
+
+        // Render AST
+        $result = $this->renderer->render($block, $childRenderer);
 
         $this->assertIsString($result);
-        $this->assertEquals("- ::children::\n", $result);
+        $this->assertEquals("- List Item Value\n", $result);
     }
 }

--- a/tests/Renderer/Block/ListItemRendererTest.php
+++ b/tests/Renderer/Block/ListItemRendererTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Wnx\CommonmarkMarkdownRenderer\Tests\Renderer\Block;
 
+use League\CommonMark\Extension\CommonMark\Node\Block\ListBlock;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListData;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListItem;
 use PHPUnit\Framework\Attributes\Test;
@@ -23,13 +24,16 @@ final class ListItemRendererTest extends TestCase
     #[Test]
     public function it_renders_unordered_list(): void
     {
-        $block = new ListItem(new ListData());
+        $data = new ListData();
+        $data->type = ListBlock::TYPE_BULLET;
+
+        $block = new ListItem($data);
         $block->data->set('attributes/id', 'foo');
         $fakeRenderer = new FakeChildNodeRenderer();
         $fakeRenderer->pretendChildrenExist();
 
         $result = $this->renderer->render($block, $fakeRenderer);
 
-        $this->assertEquals('::children::', $result);
+        $this->assertEquals(' ::children::', $result);
     }
 }

--- a/tests/stubs/kitchen-sink-expected.md
+++ b/tests/stubs/kitchen-sink-expected.md
@@ -5,14 +5,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Curiosities
 
-- This is a list item which is followed by an indented content on the next line   
+- This is a list item which is followed by an indented content on the next line
   which is part of the same list item
-- This is a list item which contains multiple paragraphs   
-  This is the second paragraph.   
+- This is a list item which contains multiple paragraphs
+  This is the second paragraph.
   This is the third paragraph.
-- This is a list item with multiple paragraphs, but without trailing whitespace in the original document at the end   
-  This is the second paragraph.   
+- This is a list item with multiple paragraphs, but without trailing whitespace in the original document at the end
+  This is the second paragraph.
   This is the third paragraph.
+
+* This list is indented a little further
+  It's using 4 characters to indent items. For some reason league/commonmark reports 2 though...
+* And it uses asterisks to denote list items
+
+0. this ordered list starts with 0.
+0. And it uses 0 for the second item.
+3. And then it uses 3 here! But that's valid too.
+
+1) And this list uses parenthesis for its delimiter
+2) and that's fine too.
 
 ## Task List
 

--- a/tests/stubs/kitchen-sink.md
+++ b/tests/stubs/kitchen-sink.md
@@ -14,6 +14,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   This is the second paragraph.
   This is the third paragraph.
 
+* This list is indented a little further
+    It's using 4 characters to indent items. For some reason league/commonmark reports 2 though...
+* And it uses asterisks to denote list items
+
+0. this ordered list starts with 0.
+0. And it uses 0 for the second item.
+3. And then it uses 3 here! But that's valid too.
+
+1) And this list uses parenthesis for its delimiter
+2) and that's fine too.
+
 ## Task List
 
 - [ ] Task 1


### PR DESCRIPTION
Fixes #12

List items are now responsible for adding appropriate padding and setting the correct list type, which matches the original source.

I gave this a go with nested lists - the kitchen sink failed that, but it fails in the same (or at least a similar) way for the existing code so I don't think that's a degradation. In both scenarios it can't figure out what level of padding it should give the nested lists, and sometimes adds extra lines. I've raised https://github.com/stefanzweifel/commonmark-markdown-renderer/issues/13 to track fixing that separately.

Note that this still fails `ListBlockRendererTest`  - I don't understand what the intention of the `::children::` placeholders are so I didn't touch those tests.