### PR TITLE
Fix rendering of indented code block

### DIFF
--- a/src/Renderer/Block/IndentedCodeRenderer.php
+++ b/src/Renderer/Block/IndentedCodeRenderer.php
@@ -22,10 +22,11 @@ final class IndentedCodeRenderer implements NodeRendererInterface
     {
         IndentedCode::assertInstanceOf($node);
 
-        $content = $node->getLiteral();
+        $content = [];
+        foreach (explode("\n", $node->getLiteral()) as $line) {
+            $content[] = "    {$line}";
+        }
 
-        return <<<TXT
-        ```{$content}```
-        TXT;
+        return implode("\n", $content);
     }
 }

--- a/tests/Renderer/Block/IndentedCodeRendererTest.php
+++ b/tests/Renderer/Block/IndentedCodeRendererTest.php
@@ -35,6 +35,6 @@ final class IndentedCodeRendererTest extends TestCase
 
         $result = $this->renderer->render($block, $fakeRenderer);
 
-        $this->assertEquals('```echo "hello world!";```', $result);
+        $this->assertEquals('    echo "hello world!";', $result);
     }
 }


### PR DESCRIPTION
Renders an indented code block as an indented code block.

Haven't added it to sink - so it's ambiguous whether this would render correctly as a part of a list item, but that was already the case.

## Issue
- https://github.com/stefanzweifel/commonmark-markdown-renderer/issues/10